### PR TITLE
Very basic Greenbeam first pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 
 _This is an experiment in adapting an existing browser extension to see if it's possible to use tools like browser extensions to surface demand from end users of services, to have the sites and services they use run on renewable power_.
 
-_See the [issues](https://github.com/mrchrisadams/greenbeam/issues) for more_, and the [initial Prototype funding application in English](https://github.com/mrchrisadams/greenbeam/blob/master/docs/prototype-fund-application.md) to understand the idea in more detail
+_See the [issues](https://github.com/eveahe/greenbeam/issues) for more_, and the [initial Prototype funding application in English](https://github.com/mrchrisadams/greenbeam/blob/master/docs/prototype-fund-application.md) to understand the idea in more detail
 
+Below are the original Lightbeam instructions on cloning, installing and running the extension.
 
+--- 
 
 This is the web extension version of the Firefox Lightbeam add-on for visualizing HTTP requests between websites in real time.
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,4 +1,3 @@
-
 /* ----------- VISUALIZATION ----------- */
 
 .links line {
@@ -28,15 +27,17 @@
   --tertiary-color: #eaeaea;
   --button-color: #171e25;
   --button-border-color: #12181b;
-  --button-active-color: #73a4b8;
-  --button-active-border-color: #6fc3e5;
+  --button-active-color: limegreen;
+  --button-active-border-color: palegreen;
   --primary-text-color: #eaeaea;
-  --secondary-text-color: #73a4b8;
-  --dialog-header-color: #4cc7e6;
-  --dialog-button-color: #4cc7e6;
+  --secondary-text-color: limegreen;
+  --dialog-header-color: palegreen;
+  --dialog-button-color: palegreen;
 }
 
-*::before, *::after, * {
+*::before,
+*::after,
+* {
   box-sizing: border-box;
 }
 
@@ -50,7 +51,12 @@ body {
   font-weight: normal;
 }
 
-h1, h2, h3, dt, dd, label {
+h1,
+h2,
+h3,
+dt,
+dd,
+label {
   margin: 0;
   font-weight: 400;
 }
@@ -59,13 +65,16 @@ h1 {
   font-size: 1.75em;
 }
 
-h2, dt, label {
+h2,
+dt,
+label {
   font-size: .75em;
   font-weight: 700;
   text-transform: uppercase;
 }
 
-h3, dd {
+h3,
+dd {
   font-size: 1.2em;
   color: var(--secondary-text-color);
   text-transform: uppercase;
@@ -98,7 +107,8 @@ button:hover {
   background-color: var(--button-active-color);
 }
 
-button::before, a.thumbs-up::before {
+button::before,
+a.thumbs-up::before {
   content: "";
   display: inline-block;
   background-repeat: no-repeat;
@@ -129,7 +139,7 @@ dialog {
   color: black;
   border: none;
   border-radius: 0.5em;
-  box-shadow: 0.5em 0.5em 0 rgba(0,0,0,0.5);
+  box-shadow: 0.5em 0.5em 0 rgba(0, 0, 0, 0.5);
   overflow: hidden;
 }
 
@@ -137,11 +147,12 @@ dialog:not([open]) {
   display: none;
 }
 
-dialog::backdrop, dialog + .backdrop {
-  background: rgba(0,0,0,0.25);
+dialog::backdrop,
+dialog+.backdrop {
+  background: rgba(0, 0, 0, 0.25);
 }
 
-dialog + .backdrop {
+dialog+.backdrop {
   position: fixed;
   top: 0;
   right: 0;
@@ -179,7 +190,7 @@ dialog .dialog-content {
   grid-row: 2;
 }
 
-dialog .dialog-icon + .dialog-content {
+dialog .dialog-icon+.dialog-content {
   grid-column: 2 / 5;
 }
 
@@ -223,7 +234,7 @@ dialog .dialog-options button:focus {
   }
 
   dialog .dialog-content,
-  dialog .dialog-icon + .dialog-content {
+  dialog .dialog-icon+.dialog-content {
     grid-column: 1 / 5;
   }
 }
@@ -343,12 +354,12 @@ main {
   padding: 20px;
 }
 
-.top-bar > dl {
+.top-bar>dl {
   display: flex;
   flex-wrap: wrap;
 }
 
-.top-bar > dl > div {
+.top-bar>dl>div {
   margin-right: 15px;
 }
 
@@ -358,13 +369,13 @@ main {
   flex-wrap: wrap;
 }
 
-#tracking-protection-disabled > div {
+#tracking-protection-disabled>div {
   display: inline-block;
   width: 140px;
   margin-inline-start: 10px;
 }
 
-#tracking-protection-disabled > div > a {
+#tracking-protection-disabled>div>a {
   font-size: 1rem;
   text-decoration: none;
 }
@@ -388,7 +399,7 @@ main {
 }
 
 .toggle-switch:active {
-  border:1px solid var(--button-active-border-color);
+  border: 1px solid var(--button-active-border-color);
 }
 
 .toggle:before {
@@ -414,13 +425,13 @@ main {
   top: 30%;
 }
 
-.toggle-switch input:checked + .toggle:before {
+.toggle-switch input:checked+.toggle:before {
   transform: translateX(20px);
   right: 10%;
   background-color: var(--secondary-text-color);
 }
 
-.toggle-switch input:checked + .toggle:after {
+.toggle-switch input:checked+.toggle:after {
   content: "ON";
   left: 10%;
 }
@@ -439,11 +450,11 @@ main {
   background-color: var(--primary-color);
 }
 
-.vis-header > h1 {
+.vis-header>h1 {
   color: var(--primary-text-color);
 }
 
-.vis-header > h2 {
+.vis-header>h2 {
   color: var(--secondary-text-color);
 }
 
@@ -483,9 +494,7 @@ main {
   grid-row-end: span 3;
 }
 
-.info-panel-controls {
-
-}
+.info-panel-controls {}
 
 .info-panel {
   border-radius: 3px 0 0 3px;

--- a/src/index.html
+++ b/src/index.html
@@ -1,24 +1,29 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="x-ua-compatible" content="IE=edge">
-    <title>Firefox Lightbeam</title>
-    <meta name="description" content="Firefox Lightbeam is a Firefox add-on that uses interactive visualizations to show you the relationships between third parties and the sites you visit.">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" href="images/lightbeam-48.png" type="image/x-icon">
-    <link rel="icon" href="images/lightbeam-48.png" type="image/x-icon">
-    <link rel="stylesheet" href="css/style.css" type="text/css">
-    <script src="js/storeChild.js" type="text/javascript"></script>
-    <script src="ext-libs/d3.min.js"></script>
-    <script src="ext-libs/dialog-polyfill.js"></script>
-    <script src="js/viz.js" type="text/javascript"></script>
-    <script src="js/lightbeam.js" type="text/javascript"></script>
-  </head>
-  <body>
-    <aside class="max-graph">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="IE=edge">
+  <title>Firefox Lightbeam</title>
+  <meta name="description"
+    content="Firefox Lightbeam is a Firefox add-on that uses interactive visualizations to show you the relationships between third parties and the sites you visit.">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="images/lightbeam-48.png" type="image/x-icon">
+  <link rel="icon" href="images/lightbeam-48.png" type="image/x-icon">
+  <link rel="stylesheet" href="css/style.css" type="text/css">
+  <script src="js/greencheck.js" type="text/javascript"></script>
+  <script src="js/storeChild.js" type="text/javascript"></script>
+  <script src="ext-libs/d3.min.js"></script>
+  <script src="ext-libs/dialog-polyfill.js"></script>
+  <script src="js/viz.js" type="text/javascript"></script>
+  <script src="js/lightbeam.js" type="text/javascript"></script>
+</head>
+
+<body>
+  <aside class="max-graph">
     <header>
-      <img class="logo" role="banner" src="images/lightbeam_150x45.png">
+      <h3 style="color:limegreen">GREENBEAM</h1>
+        <!-- <img class="logo" role="banner" src="images/lightbeam_150x45.png"> -->
     </header>
     <nav role="navigation">
       <h2>Visualization</h2>
@@ -35,118 +40,121 @@
       </div>
       <div class="nav-links">
         <!-- @todo confirm feedback URL -->
-        <a class="thumbs-up" href="mailto:lightbeam-feedback@mozilla.org">Give Us Feedback</a>
+        <!-- <a class="thumbs-up" href="mailto:lightbeam-feedback@mozilla.org">Give Us Feedback</a> -->
       </div>
     </nav>
-    </aside>
-    <main role="main">
-      <section class="top-bar max-graph">
-        <dl class="info-headings">
-          <div>
-            <dt>Data Gathered Since</dt>
-            <dd>
-              <time id="data-gathered-since" datetime=""></time>
-            </dd>
-          </div>
-          <div>
-            <dt>You Have Visited</dt>
-            <dd>
-              <var id="num-first-parties"></var>
-            </dd>
-          </div>
-          <div>
-            <dt>You Have Connected With</dt>
-            <dd>
-              <var id="num-third-parties"></var>
-            </dd>
-          </div>
-        </dl>
-        <!-- @todo add tracking protection and toggle functionality -->
-        <div class="tracking-protection" id="tracking-protection">
-          <label>Tracking Protection</label>
-          <div class="toggle-switch">
-            <label for="tracking-protection-control">
-              <input type="checkbox" id="tracking-protection-control">
-              <span class="toggle"></span>
-            </label>
-          </div>
+  </aside>
+  <main role="main">
+    <section class="top-bar max-graph">
+      <dl class="info-headings">
+        <div>
+          <dt>Data Gathered Since</dt>
+          <dd>
+            <time id="data-gathered-since" datetime=""></time>
+          </dd>
         </div>
-        <div class="tracking-protection" id="tracking-protection-disabled" hidden>
-          <label>Tracking Protection</label>
-          <div title="Due to technical issues this doesn't work in current Firefox. Please visit Firefox preferences to enable instead.">
-            Coming back in <a href="https://www.mozilla.org/en-US/firefox/quantum/">Firefox Quantum</a>
-          </div>
+        <div>
+          <dt>You Have Visited</dt>
+          <dd>
+            <var id="num-first-parties"></var>
+          </dd>
         </div>
+        <div>
+          <dt>You Have Connected With</dt>
+          <dd>
+            <var id="num-third-parties"></var>
+          </dd>
         </div>
-      </section>
-      <section class="vis">
-        <div class="vis-header max-graph">
-          <!-- @todo update filter with current filter state -->
-          <h1 id="filter">Recent Site</h1>
-          <!-- @todo update view with current view state -->
-          <h2><span id="view">Graph</span> View</h2>
-          <!-- @todo display list or graph view, update view based on filter and controls -->
-          <!-- @todo remove the hard-coded width, height values -->
+      </dl>
+      <!-- @todo add tracking protection and toggle functionality -->
+      <div class="tracking-protection" id="tracking-protection">
+        <label>Tracking Protection</label>
+        <div class="toggle-switch">
+          <label for="tracking-protection-control">
+            <input type="checkbox" id="tracking-protection-control">
+            <span class="toggle"></span>
+          </label>
         </div>
-        <div class="vis-controls info-panel-controls unimplemented">
-          <!-- @todo check purpose of website icon -->
-          <button class="info-panel website"></button>
-          <!-- @todo add help sidebar -->
-          <button class="info-panel help"></button>
-          <!-- @todo add about sidebar -->
-          <button class="info-panel about"></button>
+      </div>
+      <div class="tracking-protection" id="tracking-protection-disabled" hidden>
+        <label>Tracking Protection</label>
+        <div
+          title="Due to technical issues this doesn't work in current Firefox. Please visit Firefox preferences to enable instead.">
+          Coming back in <a href="https://www.mozilla.org/en-US/firefox/quantum/">Firefox Quantum</a>
         </div>
-        <div class="vis-content" id="visualization">
-          <div id="tooltip"></div>
+      </div>
+      </div>
+    </section>
+    <section class="vis">
+      <div class="vis-header max-graph">
+        <!-- @todo update filter with current filter state -->
+        <h1 id="filter">Recent Site</h1>
+        <!-- @todo update view with current view state -->
+        <h2><span id="view">Graph</span> View</h2>
+        <!-- @todo display list or graph view, update view based on filter and controls -->
+        <!-- @todo remove the hard-coded width, height values -->
+      </div>
+      <div class="vis-controls info-panel-controls unimplemented">
+        <!-- @todo check purpose of website icon -->
+        <button class="info-panel website"></button>
+        <!-- @todo add help sidebar -->
+        <button class="info-panel help"></button>
+        <!-- @todo add about sidebar -->
+        <button class="info-panel about"></button>
+      </div>
+      <div class="vis-content" id="visualization">
+        <div id="tooltip"></div>
+      </div>
+    </section>
+    <footer class="unimplemented">
+      <div class="footer-toggle unimplemented">
+        <div class="footer-heading">
+          <h2>Toggle Controls</h2>
         </div>
-      </section>
-      <footer class="unimplemented">
-        <div class="footer-toggle unimplemented">
-          <div class="footer-heading">
-            <h2>Toggle Controls</h2>
-          </div>
-          <!-- @todo highlight active controls, add click to toggle controls -->
-          <div class="footer-toggle-buttons controls">
-            <button class="visited-sites active">Visited Sites</button>
-            <button class="watched-sites two-icons active">Watched Sites</button>
-            <button class="cookies active">Cookies</button>
-            <button class="third-party-sites active">Third Party Sites</button>
-            <button class="blocked-sites two-icons active">Blocked Sites</button>
-            <button class="connections active">Connections</button>
-          </div>
+        <!-- @todo highlight active controls, add click to toggle controls -->
+        <div class="footer-toggle-buttons controls">
+          <button class="visited-sites active">Visited Sites</button>
+          <button class="watched-sites two-icons active">Watched Sites</button>
+          <button class="cookies active">Cookies</button>
+          <button class="third-party-sites active">Third Party Sites</button>
+          <button class="blocked-sites two-icons active">Blocked Sites</button>
+          <button class="connections active">Connections</button>
         </div>
-        <div class="footer-filter unimplemented">
-          <div class="footer-heading">
-            <h2>Filter</h2>
-            <!-- @todo add click for hide to toggle filter menu-->
-            <h2 class="hide">Hide</h2>
-          </div>
-          <div class="filter-menu">
+      </div>
+      <div class="footer-filter unimplemented">
+        <div class="footer-heading">
+          <h2>Filter</h2>
+          <!-- @todo add click for hide to toggle filter menu-->
+          <h2 class="hide">Hide</h2>
+        </div>
+        <div class="filter-menu">
           <!-- @todo highlight active filter, add click to toggle filter -->
-            <button class="active">Recent Site</button>
-            <button>Last 10 Sites</button>
-            <button>Daily</button>
-            <button>Weekly</button>
-          </div>
+          <button class="active">Recent Site</button>
+          <button>Last 10 Sites</button>
+          <button>Daily</button>
+          <button>Weekly</button>
         </div>
-      </footer>
-    </main>
-    <dialog id="reset-data-dialog" aria-labelledby="reset-data-dialog-title">
-      <form method="dialog" class="dialog-wrapper">
-        <h1 id="reset-data-dialog-title" class="dialog-title">Reset Data</h1>
+      </div>
+    </footer>
+  </main>
+  <dialog id="reset-data-dialog" aria-labelledby="reset-data-dialog-title">
+    <form method="dialog" class="dialog-wrapper">
+      <h1 id="reset-data-dialog-title" class="dialog-title">Reset Data</h1>
 
-        <img class="dialog-icon" src="images/lightbeam_dialog_warningreset.png" alt="">
+      <img class="dialog-icon" src="images/lightbeam_dialog_warningreset.png" alt="">
 
-        <div class="dialog-content">
-          <p>Pressing OK will delete all Lightbeam information including connection history, user preferences, block sites list, etc.</p>
-          <p>Your browser will be returned to the state of a fresh install of Lightbeam.</p>
-        </div>
+      <div class="dialog-content">
+        <p>Pressing OK will delete all Lightbeam information including connection history, user preferences, block sites
+          list, etc.</p>
+        <p>Your browser will be returned to the state of a fresh install of Lightbeam.</p>
+      </div>
 
-        <menu class="dialog-options">
-          <button type="submit" value="" autofocus>Cancel</button>
-          <button type="submit" value="confirm">OK</button>
-        </menu>
-      </form>
-    </dialog>
-  </body>
+      <menu class="dialog-options">
+        <button type="submit" value="" autofocus>Cancel</button>
+        <button type="submit" value="confirm">OK</button>
+      </menu>
+    </form>
+  </dialog>
+</body>
+
 </html>

--- a/src/js/capture.js
+++ b/src/js/capture.js
@@ -20,6 +20,8 @@ const capture = {
       };
       //  Added by Eve Add an if statement here to stop the madness!!!
       if (response.url === greenWebAPI || response.url === 'http://api.thegreenwebfoundation.org/greencheck/') {
+        console.log(eventDetails);
+        console.log("this is the response.url " + response.url)
         return;
       } else {
         this.queue.push(eventDetails);
@@ -42,7 +44,7 @@ const capture = {
         console.log('tab.url ' + tab.url);
         const greenWebAPI = 'http://api.thegreenwebfoundation.org/greencheck/api.thegreenwebfoundation.org';
         if (tab.url === greenWebAPI || tab.url === 'http://api.thegreenwebfoundation.org/greencheck/') {
-          return
+          return;
         } else {
           this.queue.push(eventDetails);
           this.processNextEvent();
@@ -181,7 +183,7 @@ const capture = {
     }
     //  Trying to stop all the loops of calls to the API!!
     const greenStatus = await checkGreenStatus(targetUrl.hostname).then(data => {
-      return data.green
+      return data.green;
     });
     console.log('this is from sendThirdParty ' + targetUrl.hostname);
     console.log(greenStatus);
@@ -211,7 +213,7 @@ const capture = {
     //  Added by Greenbeam. Here we are checking whether a given website is hosted by renewables.
     //  This works for most first parties but confusing sometimes does not seem to work.
     const greenStatus = await checkGreenStatus(documentUrl.hostname).then(data => {
-      return data.green
+      return data.green;
     });
     //  End of the Greenbeam additions.
     if (documentUrl.hostname &&
@@ -231,11 +233,11 @@ const capture = {
 //Eve is messing around below!! This should really be in a separate file!!!
 async function checkGreenStatus(url) {
   if (url === 'api.thegreenwebfoundation.org') {
-    return
+    return;
   } else {
     const response = await fetch(`http://api.thegreenwebfoundation.org/greencheck/${url}`);
-    const data = await response.json()
-    return data
+    const data = await response.json();
+    return data;
   }
 }
 

--- a/src/js/capture.js
+++ b/src/js/capture.js
@@ -18,14 +18,15 @@ const capture = {
         type: 'sendThirdParty',
         data: response
       };
+      //Things to filter out: 
       //  Added by Eve Add an if statement here to stop the madness!!!
-      if (response.url === greenWebAPI || response.url === 'http://api.thegreenwebfoundation.org/greencheck/') {
-        console.log(eventDetails);
-        console.log("this is the response.url " + response.url)
+      // if (response.url === greenWebAPI || response.url === 'http://api.thegreenwebfoundation.org/greencheck/') {
+      if (isBadUrl(response.url)) {
         return;
       } else {
         this.queue.push(eventDetails);
         this.processNextEvent();
+        console.log("response.url ", response.url)
       }
     }, {
       urls: ['<all_urls>']
@@ -43,10 +44,11 @@ const capture = {
         };
         console.log('tab.url ' + tab.url);
         const greenWebAPI = 'http://api.thegreenwebfoundation.org/greencheck/api.thegreenwebfoundation.org';
-        if (tab.url === greenWebAPI || tab.url === 'http://api.thegreenwebfoundation.org/greencheck/') {
+        if (isBadUrl(tab.url)) {
           return;
         } else {
           this.queue.push(eventDetails);
+          console.log(tab + " logging from line 50")
           this.processNextEvent();
         }
       });
@@ -65,6 +67,8 @@ const capture = {
     if (this.queue.length >= 1) {
       try {
         const nextEvent = this.queue.shift();
+        console.log("nextEvent ", nextEvent)
+        console.log(this.queue.length)
         this.processingQueue = true;
         switch (nextEvent.type) {
           case 'sendFirstParty':
@@ -239,6 +243,11 @@ async function checkGreenStatus(url) {
     const data = await response.json();
     return data;
   }
+}
+
+function isBadUrl(url) {
+  const badURLS = ['http://127.0.0.1:5500/', 'http://api.thegreenwebfoundation.org/greencheck/', 'moz-extension://']
+  return badURLS.some(badURL => url.startsWith(badURL))
 }
 
 //End of eve messing around.

--- a/src/js/capture.js
+++ b/src/js/capture.js
@@ -9,8 +9,6 @@ const capture = {
   },
 
   addListeners() {
-    //  Eve added first the below!
-    const greenWebAPI = 'http://api.thegreenwebfoundation.org/greencheck/api.thegreenwebfoundation.org';
     // listen for each HTTP response
     this.queue = [];
     browser.webRequest.onResponseStarted.addListener((response) => {
@@ -18,15 +16,12 @@ const capture = {
         type: 'sendThirdParty',
         data: response
       };
-      //Things to filter out: 
-      //  Added by Eve Add an if statement here to stop the madness!!!
-      // if (response.url === greenWebAPI || response.url === 'http://api.thegreenwebfoundation.org/greencheck/') {
+      //  Greenbeam. Filtering out urls (eg, the API) to not trigger events.
       if (isBadUrl(response.url)) {
         return;
       } else {
         this.queue.push(eventDetails);
         this.processNextEvent();
-        console.log("response.url ", response.url)
       }
     }, {
       urls: ['<all_urls>']
@@ -42,13 +37,10 @@ const capture = {
             tab
           }
         };
-        console.log('tab.url ' + tab.url);
-        const greenWebAPI = 'http://api.thegreenwebfoundation.org/greencheck/api.thegreenwebfoundation.org';
         if (isBadUrl(tab.url)) {
           return;
         } else {
           this.queue.push(eventDetails);
-          console.log(tab + " logging from line 50")
           this.processNextEvent();
         }
       });
@@ -67,8 +59,6 @@ const capture = {
     if (this.queue.length >= 1) {
       try {
         const nextEvent = this.queue.shift();
-        console.log("nextEvent ", nextEvent)
-        console.log(this.queue.length)
         this.processingQueue = true;
         switch (nextEvent.type) {
           case 'sendFirstParty':
@@ -189,8 +179,6 @@ const capture = {
     const greenStatus = await checkGreenStatus(targetUrl.hostname).then(data => {
       return data.green;
     });
-    console.log('this is from sendThirdParty ' + targetUrl.hostname);
-    console.log(greenStatus);
     //  Eve mostly ends here!!
     if (firstPartyUrl.hostname &&
       targetUrl.hostname !== firstPartyUrl.hostname &&
@@ -214,8 +202,8 @@ const capture = {
   // capture first party requests
   async sendFirstParty(tabId, changeInfo, tab) {
     const documentUrl = new URL(tab.url);
-    //  Added by Greenbeam. Here we are checking whether a given website is hosted by renewables.
-    //  This works for most first parties but confusing sometimes does not seem to work.
+    // Greenbeam. Checking whether a given website is hosted by renewables.
+    // Note that for first parties it may take a wahile to load.
     const greenStatus = await checkGreenStatus(documentUrl.hostname).then(data => {
       return data.green;
     });
@@ -234,7 +222,7 @@ const capture = {
 };
 
 
-//Eve is messing around below!! This should really be in a separate file!!!
+// Greenbeam. The function to check the url against the API
 async function checkGreenStatus(url) {
   if (url === 'api.thegreenwebfoundation.org') {
     return;
@@ -246,8 +234,8 @@ async function checkGreenStatus(url) {
 }
 
 function isBadUrl(url) {
-  const badURLS = ['http://127.0.0.1:5500/', 'http://api.thegreenwebfoundation.org/greencheck/', 'moz-extension://']
-  return badURLS.some(badURL => url.startsWith(badURL))
+  const badURLS = ['http://127.0.0.1:5500/', 'http://api.thegreenwebfoundation.org/greencheck/', 'moz-extension://'];
+  return badURLS.some(badURL => url.startsWith(badURL));
 }
 
 //End of eve messing around.

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -13,18 +13,15 @@ const lightbeam = {
   },
 
   async initTPToggle() {
-    const toggleCheckbox
-      = document.getElementById('tracking-protection-control');
+    const toggleCheckbox = document.getElementById('tracking-protection-control');
     const trackingProtection = document.getElementById('tracking-protection');
-    const trackingProtectionDisabled
-      = document.getElementById('tracking-protection-disabled');
+    const trackingProtectionDisabled = document.getElementById('tracking-protection-disabled');
     // Do we support setting TP
     if ('trackingProtectionMode' in browser.privacy.websites) {
       trackingProtection.hidden = false;
       trackingProtectionDisabled.hidden = true;
 
-      const trackingProtectionState
-        = await browser.privacy.websites.trackingProtectionMode.get({});
+      const trackingProtectionState = await browser.privacy.websites.trackingProtectionMode.get({});
       let value = true;
       if (trackingProtectionState.value !== 'always') {
         value = false;
@@ -32,7 +29,9 @@ const lightbeam = {
       toggleCheckbox.checked = value;
       toggleCheckbox.addEventListener('change', () => {
         const value = toggleCheckbox.checked ? 'always' : 'private_browsing';
-        browser.privacy.websites.trackingProtectionMode.set({ value });
+        browser.privacy.websites.trackingProtectionMode.set({
+          value
+        });
       });
     } else {
       trackingProtection.hidden = true;
@@ -59,13 +58,15 @@ const lightbeam = {
 
     // initialize dynamic vars from storage
     if (!this.dataGatheredSince) {
-      const { dateStr, fullDateTime } = await this.getDataGatheredSince();
+      const {
+        dateStr,
+        fullDateTime
+      } = await this.getDataGatheredSince();
       if (!dateStr) {
         return;
       }
       this.dataGatheredSince = dateStr;
-      const dataGatheredSinceElement
-        = document.getElementById('data-gathered-since');
+      const dataGatheredSinceElement = document.getElementById('data-gathered-since');
       dataGatheredSinceElement.textContent = this.dataGatheredSince || '';
       dataGatheredSinceElement.setAttribute('datetime', fullDateTime || '');
     }
@@ -240,13 +241,14 @@ const lightbeam = {
     const saveData = document.getElementById('save-data-button');
     saveData.addEventListener('click', async () => {
       const data = await storeChild.getAll();
-      const blob = new Blob([JSON.stringify(data ,' ' , 2)],
-        {type : 'application/json'});
+      const blob = new Blob([JSON.stringify(data, ' ', 2)], {
+        type: 'application/json'
+      });
       const url = window.URL.createObjectURL(blob);
       const downloading = browser.downloads.download({
-        url : url,
-        filename : 'lightbeamData.json',
-        conflictAction : 'uniquify'
+        url: url,
+        filename: 'lightbeamData.json',
+        conflictAction: 'uniquify'
       });
       await downloading;
     });

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -48,11 +48,7 @@ const lightbeam = {
     this.downloadData();
     this.resetData();
     storeChild.onUpdate((data) => {
-      try {
-        this.redraw(data);
-      } catch (e) {
-        console.log(e)
-      }
+      this.redraw(data);
     });
   },
 

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -48,7 +48,11 @@ const lightbeam = {
     this.downloadData();
     this.resetData();
     storeChild.onUpdate((data) => {
-      this.redraw(data);
+      try {
+        this.redraw(data);
+      } catch (e) {
+        console.log(e)
+      }
     });
   },
 

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -14,12 +14,14 @@ const store = {
 
   async isFirstRun() {
     let isFirstRun = await browser.storage.local.get('isFirstRun');
-    if (! ('isFirstRun' in isFirstRun)) {
+    if (!('isFirstRun' in isFirstRun)) {
       isFirstRun = true;
     } else if (isFirstRun) {
       isFirstRun = false;
     }
-    await browser.storage.local.set({ isFirstRun });
+    await browser.storage.local.set({
+      isFirstRun
+    });
     return isFirstRun;
   },
 
@@ -28,13 +30,16 @@ const store = {
     'firstRequestTime',
     'lastRequestTime',
     'isVisible',
-    'firstParty'
+    'firstParty',
+    'greenCheckTest'
   ],
 
   makeNewDatabase() {
     this.db = new Dexie('websites_database');
     const websites = this.indexes.join(', ');
-    this.db.version(1).stores({websites});
+    this.db.version(1).stores({
+      websites
+    });
     this.db.open();
   },
 
@@ -50,8 +55,10 @@ const store = {
       // eslint-disable-next-line no-console
       console.error(`${error.message} ${explanation} ${this.ALLOWLIST_URL}`);
     }
-    const { firstPartyAllowList, thirdPartyAllowList }
-      = this.reformatList(allowList);
+    const {
+      firstPartyAllowList,
+      thirdPartyAllowList
+    } = this.reformatList(allowList);
     this.firstPartyAllowList = firstPartyAllowList;
     this.thirdPartyAllowList = thirdPartyAllowList;
   },
@@ -162,16 +169,25 @@ const store = {
   },
 
   outputWebsite(hostname, website) {
+    //note that once again eve is messing around here.
+    // let greenStatus = checkGreenStatus(hostname).then(data => {
+    //   return data.green
+    // });
+    //end of eve messing around!!
     const output = {
       hostname: hostname,
       favicon: website.faviconUrl || '',
       firstPartyHostnames: website.firstPartyHostnames || false,
       firstParty: !!website.firstParty,
-      thirdParties: []
+      thirdParties: [],
+      //Eve is of course messing around with the below variable!!
+      // greenCheck: greenStatus,
+      greenCheckTest: website.greenCheckTest
     };
     if ('thirdPartyHostnames' in website) {
       output.thirdParties = website.thirdPartyHostnames;
     }
+    console.log(output);
     return output;
   },
 
@@ -181,8 +197,7 @@ const store = {
     }).toArray();
     const output = {};
     for (const website of websites) {
-      output[website.hostname]
-        = this.outputWebsite(website.hostname, website);
+      output[website.hostname] = this.outputWebsite(website.hostname, website);
     }
     return output;
   },
@@ -254,6 +269,10 @@ const store = {
     if (!('hostname' in website)) {
       website['hostname'] = hostname;
     }
+    //Eve is messing around here!!
+    // console.log("test " + hostname);
+    // checkGreenStatus(hostname);
+    //end eve messing around.
 
     for (const key in data) {
       const value = data[key];
@@ -267,16 +286,16 @@ const store = {
           }
           break;
         case 'isVisible':
-          if ('isVisible' in website
-              && website.isVisible === true) {
+          if ('isVisible' in website &&
+            website.isVisible === true) {
             // once a website is visible, it will always be visible
             break;
           }
           website.isVisible = value;
           break;
         case 'firstParty':
-          if ('firstParty' in website
-              && website.firstParty === true) {
+          if ('firstParty' in website &&
+            website.firstParty === true) {
             // once a website is a first party, it will always be drawn as one
             break;
           }
@@ -320,15 +339,13 @@ const store = {
   // returns true if it is and false otherwise
   onAllowList(firstPartyFromRequest, thirdPartyFromRequest) {
     if (thirdPartyFromRequest && this.firstPartyAllowList) {
-      const hostnameVariantsFirstParty
-        = this.getHostnameVariants(firstPartyFromRequest);
+      const hostnameVariantsFirstParty = this.getHostnameVariants(firstPartyFromRequest);
       for (let i = 0; i < hostnameVariantsFirstParty.length; i++) {
         if (this.firstPartyAllowList
           .hasOwnProperty(hostnameVariantsFirstParty[i])) {
           // first party is in the allowlist
           const index = this.firstPartyAllowList[hostnameVariantsFirstParty[i]];
-          const hostnameVariantsThirdParty
-            = this.getHostnameVariants(thirdPartyFromRequest);
+          const hostnameVariantsThirdParty = this.getHostnameVariants(thirdPartyFromRequest);
           for (let j = 0; j < hostnameVariantsThirdParty.length; j++) {
             if (this.thirdPartyAllowList[index]
               .includes(hostnameVariantsThirdParty[j])) {
@@ -413,8 +430,8 @@ const store = {
   },
 
   isFirstPartyLinkedToThirdParty(firstParty, thirdPartyHostname) {
-    if (!('thirdPartyHostnames' in firstParty)
-      || !firstParty['thirdPartyHostnames'].includes(thirdPartyHostname)) {
+    if (!('thirdPartyHostnames' in firstParty) ||
+      !firstParty['thirdPartyHostnames'].includes(thirdPartyHostname)) {
       return false;
     }
     return true;
@@ -449,8 +466,7 @@ const store = {
   },
 
   async getFirstRequestTime() {
-    const oldestSite
-      = await this.db.websites.orderBy('firstRequestTime').first();
+    const oldestSite = await this.db.websites.orderBy('firstRequestTime').first();
     if (!oldestSite) {
       return false;
     }

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -182,7 +182,6 @@ const store = {
     if ('thirdPartyHostnames' in website) {
       output.thirdParties = website.thirdPartyHostnames;
     }
-    console.log(output);
     return output;
   },
 

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -31,7 +31,7 @@ const store = {
     'lastRequestTime',
     'isVisible',
     'firstParty',
-    'greenCheckTest'
+    'greenCheck'
   ],
 
   makeNewDatabase() {
@@ -169,20 +169,15 @@ const store = {
   },
 
   outputWebsite(hostname, website) {
-    //note that once again eve is messing around here.
-    // let greenStatus = checkGreenStatus(hostname).then(data => {
-    //   return data.green
-    // });
-    //end of eve messing around!!
+    //  note that once again eve is messing around here.
     const output = {
       hostname: hostname,
       favicon: website.faviconUrl || '',
       firstPartyHostnames: website.firstPartyHostnames || false,
       firstParty: !!website.firstParty,
       thirdParties: [],
-      //Eve is of course messing around with the below variable!!
-      // greenCheck: greenStatus,
-      greenCheckTest: website.greenCheckTest
+      //  Eve is of course messing around with the below variable!!
+      greenCheck: website.greenCheck
     };
     if ('thirdPartyHostnames' in website) {
       output.thirdParties = website.thirdPartyHostnames;
@@ -269,11 +264,6 @@ const store = {
     if (!('hostname' in website)) {
       website['hostname'] = hostname;
     }
-    //Eve is messing around here!!
-    // console.log("test " + hostname);
-    // checkGreenStatus(hostname);
-    //end eve messing around.
-
     for (const key in data) {
       const value = data[key];
       switch (key) {

--- a/src/js/viz.js
+++ b/src/js/viz.js
@@ -8,14 +8,22 @@ const viz = {
   collisionRadius: 10,
   chargeStrength: -100,
   tickCount: 100,
+  //Eve is messing around below
   canvasColor: 'white',
+  canvasTestColor: 'white',
   alphaStart: 1,
   alphaTargetStart: 0.1,
   alphaTargetStop: 0,
 
   init(nodes, links) {
-    const { width, height } = this.getDimensions();
-    const { canvas, context } = this.createCanvas();
+    const {
+      width,
+      height
+    } = this.getDimensions();
+    const {
+      canvas,
+      context
+    } = this.createCanvas();
 
     this.canvas = canvas;
     this.context = context;
@@ -55,7 +63,7 @@ const viz = {
 
   resetAlpha() {
     const alpha = this.simulation.alpha();
-    const alphaRounded =  Math.round((1 - alpha) * 100);
+    const alphaRounded = Math.round((1 - alpha) * 100);
     if (alphaRounded === 100) {
       this.simulation.alpha(this.alphaStart);
       this.restartSimulation();
@@ -126,7 +134,10 @@ const viz = {
 
   getDimensions() {
     const element = document.body;
-    const { width, height } = element.getBoundingClientRect();
+    const {
+      width,
+      height
+    } = element.getBoundingClientRect();
 
     return {
       width,
@@ -174,8 +185,20 @@ const viz = {
       if (node.shadow) {
         this.drawShadow(x, y, radius);
       }
-
-      this.context.fillStyle = this.canvasColor;
+      //Eve is messing around here
+      if (node.hostname == 'www.nytimes.com') {
+        this.context.fillStyle = 'purple';
+      } else if (node.greenCheckTest == 1) {
+        this.context.fillStyle = 'lime'
+      } else if (node.greenCheckTest == 0) {
+        this.context.fillStyle = 'red'
+      }
+      // else if (node.firstParty) {
+      //   this.context.fillStyle = this.canvasColor;}
+      else {
+        this.context.fillStyle = this.canvasTestColor;
+      }
+      //end of eve messing around.
       this.context.closePath();
       this.context.fill();
 
@@ -282,7 +305,9 @@ const viz = {
 
   getTooltipPosition(x, y) {
     const tooltipArrowHeight = 20;
-    const { right: canvasRight } = this.canvas.getBoundingClientRect();
+    const {
+      right: canvasRight
+    } = this.canvas.getBoundingClientRect();
     const {
       height: tooltipHeight,
       width: tooltipWidth
@@ -306,7 +331,10 @@ const viz = {
     this.tooltip.innerText = title;
     this.tooltip.style.display = 'block';
 
-    const { left, top } = this.getTooltipPosition(x, y);
+    const {
+      left,
+      top
+    } = this.getTooltipPosition(x, y);
     this.tooltip.style['left'] = `${left}px`;
     this.tooltip.style['top'] = `${top}px`;
   },
@@ -349,7 +377,10 @@ const viz = {
   },
 
   getMousePosition(event) {
-    const { left, top } = this.canvas.getBoundingClientRect();
+    const {
+      left,
+      top
+    } = this.canvas.getBoundingClientRect();
 
     return {
       mouseX: event.clientX - left,
@@ -366,8 +397,11 @@ const viz = {
 
   addMouseMove() {
     this.canvas.addEventListener('mousemove', (event) => {
-      const { mouseX, mouseY } = this.getMousePosition(event);
-      const [ invertX, invertY ] = this.transform.invert([mouseX, mouseY]);
+      const {
+        mouseX,
+        mouseY
+      } = this.getMousePosition(event);
+      const [invertX, invertY] = this.transform.invert([mouseX, mouseY]);
       const node = this.getNodeAtCoordinates(invertX, invertY);
 
       if (node) {
@@ -391,7 +425,10 @@ const viz = {
     this.canvas.style.width = 0;
     this.canvas.style.height = 0;
 
-    const { width, height } = this.getDimensions('visualization');
+    const {
+      width,
+      height
+    } = this.getDimensions('visualization');
     this.updateCanvas(width, height);
     this.draw(this.nodes, this.links);
   },

--- a/src/js/viz.js
+++ b/src/js/viz.js
@@ -189,9 +189,9 @@ const viz = {
       if (node.hostname == 'www.nytimes.com') {
         this.context.fillStyle = 'purple';
       } else if (node.greenCheck == 1) {
-        this.context.fillStyle = 'lime'
+        this.context.fillStyle = 'lime';
       } else if (node.greenCheck == 0) {
-        this.context.fillStyle = 'red'
+        this.context.fillStyle = 'red';
       } else {
         this.context.fillStyle = this.canvasTestColor;
       }

--- a/src/js/viz.js
+++ b/src/js/viz.js
@@ -8,7 +8,7 @@ const viz = {
   collisionRadius: 10,
   chargeStrength: -100,
   tickCount: 100,
-  //Eve is messing around below
+  //  Eve is messing around below
   canvasColor: 'white',
   canvasTestColor: 'white',
   alphaStart: 1,
@@ -185,20 +185,17 @@ const viz = {
       if (node.shadow) {
         this.drawShadow(x, y, radius);
       }
-      //Eve is messing around here
+      //  Eve is messing around here
       if (node.hostname == 'www.nytimes.com') {
         this.context.fillStyle = 'purple';
-      } else if (node.greenCheckTest == 1) {
+      } else if (node.greenCheck == 1) {
         this.context.fillStyle = 'lime'
-      } else if (node.greenCheckTest == 0) {
+      } else if (node.greenCheck == 0) {
         this.context.fillStyle = 'red'
-      }
-      // else if (node.firstParty) {
-      //   this.context.fillStyle = this.canvasColor;}
-      else {
+      } else {
         this.context.fillStyle = this.canvasTestColor;
       }
-      //end of eve messing around.
+      //  end of eve messing around.
       this.context.closePath();
       this.context.fill();
 

--- a/src/js/viz.js
+++ b/src/js/viz.js
@@ -217,7 +217,7 @@ const viz = {
     };
   },
 
-  async loadImage(URI) {
+  loadImage(URI) {
     return new Promise((resolve, reject) => {
       if (!URI) {
         return reject();
@@ -229,7 +229,6 @@ const viz = {
         return resolve(image);
       };
       image.onerror = () => {
-        console.log('error!')
         return resolve(this.defaultIcon);
       };
       image.src = URI;
@@ -261,7 +260,7 @@ const viz = {
       tx = this.transform.applyX(x) - offset,
       ty = this.transform.applyY(y) - offset;
 
-    //Need to return if we don't have a favicon. 
+    // Greenbeam. Need to return if we don't have a favicon. 
     if (!node.favicon) {
       return;
     }

--- a/src/js/viz.js
+++ b/src/js/viz.js
@@ -217,7 +217,7 @@ const viz = {
     };
   },
 
-  loadImage(URI) {
+  async loadImage(URI) {
     return new Promise((resolve, reject) => {
       if (!URI) {
         return reject();
@@ -229,6 +229,7 @@ const viz = {
         return resolve(image);
       };
       image.onerror = () => {
+        console.log('error!')
         return resolve(this.defaultIcon);
       };
       image.src = URI;
@@ -260,6 +261,10 @@ const viz = {
       tx = this.transform.applyX(x) - offset,
       ty = this.transform.applyY(y) - offset;
 
+    //Need to return if we don't have a favicon. 
+    if (!node.favicon) {
+      return;
+    }
     if (!node.image) {
       node.image = await this.loadImage(node.favicon);
     }


### PR DESCRIPTION
**What this branch does**
- This checks the greenWebAPI for every firstparty and thirdparty site visited, and then colorcodes the nodes accordingly. 
- The trickiest part was that as the Lightbeam code was listening to all HTTP calls, to not trigger an action based on a call to the API. 
- There was also an error present in the existing Lightbeam, related to code in viz.js looking for a favicon whenever the nodes are moved, that has been fixed in this branch. 

**What this branch does not (yet) do**
- Need to decide on better (i.e., colorblind) color scheme, separate from red green.
- Does not yet make calls to carbon.txt
- Does not yet change node size on the basis of volume of visits. The first party node size is currently proportional to the number of third parties it is connected to. We could alternatively keep that and try out other ways of highlighting to users which web hosts they should follow up with. 