### PR TITLE
Make it possible to import lightbeam data - IGNORE

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -310,13 +310,8 @@ aside h2 {
   color: var(--primary-text-color);
 }
 
-/* p {
-  color: var(--button-border-color);
-  font-size: .75em;
-} */
-
 .nav-links {
-  margin-top: 20px;
+  margin-top: 10px;
   text-align: center;
 }
 
@@ -348,9 +343,12 @@ aside h2 {
   padding-right: 5px;
   /* font-size: 0.75em; */
 }
+
 .actions-box ul {
   padding: 0rem 0rem 0.2rem 0.8rem;
+  margin-top: 10px;
 }
+
 .actions-box ul li {
   padding: 0rem 0rem 0.5rem 0.5rem;
   line-height: 1.2;
@@ -361,7 +359,8 @@ aside h2 {
 }
 
 .why-site::before {
-  background-image: url("../images/lightbeam_icon_help.png")
+  background-image: url("../images/lightbeam_icon_help.png");
+  margin-top: 10px;
 }
 
 .greenbeam-site::before {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -341,13 +341,19 @@ aside h2 {
 }
 
 .actions-box {
-  background-color: var(--primary-color);
   color: var(--primary-text-color);
   border-width: 1px;
   border-radius: 3px;
   padding-left: 5px;
   padding-right: 5px;
-  font-size: .75em;
+  /* font-size: 0.75em; */
+}
+.actions-box ul {
+  padding: 0rem 0rem 0.2rem 0.8rem;
+}
+.actions-box ul li {
+  padding: 0rem 0rem 0.5rem 0.5rem;
+  line-height: 1.2;
 }
 
 .thumbs-up::before {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -578,10 +578,6 @@ footer {
   justify-content: space-between;
 }
 
-.greenbeam-footer {
-  font-size: 14px;
-}
-
 .footer-heading h2 {
   padding-bottom: 5px;
   color: var(--primary-text-color);

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -371,7 +371,7 @@ aside h2 {
 
 main {
   display: grid;
-  grid-template-rows: 15% 60% 35%;
+  grid-template-rows: 15% 75% 10%;
   background-color: var(--primary-color);
   height: 100%;
 }
@@ -554,6 +554,17 @@ main {
   background-image: url('../images/lightbeam_icon_about.png');
 }
 
+/* ---------- Credits ---------- */
+.credits {
+  z-index: 3;
+  color: var(--primary-text-color);
+  display: grid;
+  grid-template-columns: fit-content(50%);
+  font-size: 14px;
+  padding-left: 30px;
+  padding-right: 30px;
+}
+
 /* ----------- UI - vis Controls ----------- */
 footer {
   display: grid;
@@ -565,6 +576,10 @@ footer {
   display: flex;
   border-bottom: 1px solid var(--primary-text-color);
   justify-content: space-between;
+}
+
+.greenbeam-footer {
+  font-size: 14px;
 }
 
 .footer-heading h2 {

--- a/src/index.html
+++ b/src/index.html
@@ -40,8 +40,10 @@
       <h2>Take Action</h2>
       <div class="actions-box">
         <ul>
-          <li><a href="https://www.thegreenwebfoundation.org/how-to-ask-a-site-to-switch-to-using-green-power/">Ask sites to switch to a web host running on green power.</a></li>
-          <li><a href="https://www.thegreenwebfoundation.org/news/how-to-choose-a-good-green-host/">Switch your own web host</a></li>
+          <li><a href="https://www.thegreenwebfoundation.org/how-to-ask-a-site-to-switch-to-using-green-power/">Ask
+              sites to switch to a web host running on green power.</a></li>
+          <li><a href="https://www.thegreenwebfoundation.org/news/how-to-choose-a-good-green-host/">Switch your own web
+              host</a></li>
         </ul>
       </div>
       <h2>Why + How</h2>

--- a/src/index.html
+++ b/src/index.html
@@ -126,9 +126,13 @@
         <div id="tooltip"></div>
       </div>
     </section>
+    <div class="credits">
+      <h2>Greenbeam is forked from Firefox Lightbeam and uses the GreenWebFoundation's data.
+        With thanks also to the Prototype Fund and ClimateActionTech!</h2>
+    </div>
     <footer class="unimplemented">
-      <div class="footer-toggle unimplemented">
-        <div class="footer-heading">
+      <div class="footer-toggle">
+        <div class="footer-heading unimplemented">
           <h2>Toggle Controls</h2>
         </div>
         <!-- @todo highlight active controls, add click to toggle controls -->
@@ -164,9 +168,9 @@
       <img class="dialog-icon" src="images/lightbeam_dialog_warningreset.png" alt="">
 
       <div class="dialog-content">
-        <p>Pressing OK will delete all Lightbeam information including connection history, user preferences, block sites
+        <p>Pressing OK will delete all Greenbeam information including connection history, user preferences, block sites
           list, etc.</p>
-        <p>Your browser will be returned to the state of a fresh install of Lightbeam.</p>
+        <p>Your browser will be returned to the state of a fresh install of Greenbeam.</p>
       </div>
 
       <menu class="dialog-options">

--- a/src/index.html
+++ b/src/index.html
@@ -34,7 +34,7 @@
       <h2>Data</h2>
       <div>
         <!-- @todo move this to settings screen -->
-        <button class="import" id="import-data-button">Import data</button>
+        <!-- <button class="import" id="import-data-button">Import data</button> -->
         <button class="download" id="save-data-button">Save Data</button>
         <button class="reset" id="reset-data-button">Reset Data</button>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,8 @@
       </div>
       <h2>Data</h2>
       <div>
-        <!-- @todo add click to save data -->
+        <!-- @todo move this to settings screen -->
+        <button class="import" id="import-data-button">Import data</button>
         <button class="download" id="save-data-button">Save Data</button>
         <button class="reset" id="reset-data-button">Reset Data</button>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -39,8 +39,10 @@
       </div>
       <h2>Take Action</h2>
       <div class="actions-box">
-        <p>1. Ask sites to switch to a web host running on renewables.</p>
-        <p>2. Switch your own web host. </p>
+        <ul>
+          <li><a href="https://www.thegreenwebfoundation.org/how-to-ask-a-site-to-switch-to-using-green-power/">Ask sites to switch to a web host running on green power.</a></li>
+          <li><a href="https://www.thegreenwebfoundation.org/news/how-to-choose-a-good-green-host/">Switch your own web host</a></li>
+        </ul>
       </div>
       <h2>Why + How</h2>
       <div>

--- a/src/js/capture.js
+++ b/src/js/capture.js
@@ -234,7 +234,7 @@ async function checkGreenStatus(url) {
 
 // Greenbeam. Here we are filtering out anything that starts with a "badURL."
 function isBadUrl(url) {
-  const badURLS = ['http://127.0.0.1:5500/', 'http://api.thegreenwebfoundation.org/greencheck/', 'moz-extension://'];
+  const badURLS = ['http://127.0.0.1:5500', 'http://api.thegreenwebfoundation.org/greencheck', 'moz-extension://'];
   return badURLS.some(badURL => url.startsWith(badURL));
 }
 

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -264,9 +264,9 @@ const lightbeam = {
     importDataButton.addEventListener('click', async () => {
       console.log("Attempting to import data")
       // prompt for a url to try fetching
-      // let url = prompt("Where should we fetch the data from?")
+      let url = prompt("Where should we fetch the data from?")
 
-      url = "ext-libs/lightbeamData.json"
+      // url = "ext-libs/lightbeamData.json"
       // moz-extension://0f5e2a52-66b8-0940-b06a-3617ed0fce68/
       // sanity check the url
       const fetchedData = await fetch(url)

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -249,6 +249,7 @@ const lightbeam = {
       }
       nodes.push(this.websites[website]);
     }
+    console.log({ nodes, links })
 
     return {
       nodes,
@@ -265,7 +266,7 @@ const lightbeam = {
       // prompt for a url to try fetching
       // let url = prompt("Where should we fetch the data from?")
 
-      url = "moz-extension://0f5e2a52-66b8-0940-b06a-3617ed0fce68/ext-libs/lightbeamData.json"
+      url = "ext-libs/lightbeamData.json"
       // moz-extension://0f5e2a52-66b8-0940-b06a-3617ed0fce68/
       // sanity check the url
       const fetchedData = await fetch(url)
@@ -280,9 +281,10 @@ const lightbeam = {
       console.log(`dbcall`, dbCall)
       // nuke it all and start over
       console.log(`re-rendering`)
+      this.init()
       window.location.reload();
 
-      return dbcall;
+      return dbCall;
 
     })
   },

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -6,6 +6,10 @@ const lightbeam = {
   numGreenSites: 0,
 
   async init() {
+
+
+
+    console.log('initialising the viz')
     this.websites = await storeChild.getAll();
     this.initTPToggle();
     this.renderGraph();
@@ -39,6 +43,7 @@ const lightbeam = {
       trackingProtectionDisabled.hidden = false;
     }
   },
+
 
   renderGraph() {
     const transformedData = this.transformData();
@@ -258,8 +263,10 @@ const lightbeam = {
     importDataButton.addEventListener('click', async () => {
       console.log("Attempting to import data")
       // prompt for a url to try fetching
-      let url = prompt("Where should we fetch the data from?")
+      // let url = prompt("Where should we fetch the data from?")
 
+      url = "moz-extension://0f5e2a52-66b8-0940-b06a-3617ed0fce68/ext-libs/lightbeamData.json"
+      // moz-extension://0f5e2a52-66b8-0940-b06a-3617ed0fce68/
       // sanity check the url
       const fetchedData = await fetch(url)
       console.log({ fetchedData })
@@ -269,7 +276,13 @@ const lightbeam = {
       console.log(`Parsed successfully. ${Object.entries(parsedSites).length} sites to import`)
 
       // delegate work to background thread
-      return await storeChild.importSiteData(parsedSites);
+      const dbCall = await storeChild.importSiteData(parsedSites);
+      console.log(`dbcall`, dbCall)
+      // nuke it all and start over
+      console.log(`re-rendering`)
+      window.location.reload();
+
+      return dbcall;
 
     })
   },

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -51,7 +51,7 @@ const lightbeam = {
   },
 
   addListeners() {
-    this.importData()
+    // this.importData()
     this.downloadData();
     this.resetData();
     storeChild.onUpdate((data) => {

--- a/src/js/lightbeam.js
+++ b/src/js/lightbeam.js
@@ -46,6 +46,7 @@ const lightbeam = {
   },
 
   addListeners() {
+    this.importData()
     this.downloadData();
     this.resetData();
     storeChild.onUpdate((data) => {
@@ -248,6 +249,29 @@ const lightbeam = {
       nodes,
       links
     };
+  },
+
+  importData() {
+
+    const importDataButton = document.getElementById('import-data-button');
+    console.log(importDataButton)
+    importDataButton.addEventListener('click', async () => {
+      console.log("Attempting to import data")
+      // prompt for a url to try fetching
+      let url = prompt("Where should we fetch the data from?")
+
+      // sanity check the url
+      const fetchedData = await fetch(url)
+      console.log({ fetchedData })
+      // try parsing it
+      const parsedSites = await fetchedData.json()
+      console.log({ parsedSites })
+      console.log(`Parsed successfully. ${Object.entries(parsedSites).length} sites to import`)
+
+      // delegate work to background thread
+      return await storeChild.importSiteData(parsedSites);
+
+    })
   },
 
   downloadData() {

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,10 +1,12 @@
 const store = {
   ALLOWLIST_URL: '/ext-libs/disconnect-entitylist.json',
+  DB_IMPORT: '/ext-libs/lightbeamData.json',
   db: null,
 
   async init() {
     if (!this.db) {
       this.makeNewDatabase();
+      await this.importDatabase()
     }
     browser.runtime.onMessage.addListener((m) => {
       return store.messageHandler(m);
@@ -41,6 +43,23 @@ const store = {
       websites
     });
     this.db.open();
+  },
+
+  async importDatabase(websites) {
+    let dbdump;
+    dbdump = await fetch(this.DB_IMPORT);
+    dbdump = await dbdump.json();
+    console.log(dbdump)
+    for (const site in dbdump) {
+      console.log({ site })
+      let siteInfo = dbdump[site]
+      console.log({ siteInfo })
+      let res = await this._write(siteInfo)
+      console.log({ res })
+    }
+    const siteList = await this.getAll()
+    console.log({ siteList })
+
   },
 
   // get Disconnect Entity List from shavar-prod-lists submodule

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -1,3 +1,4 @@
+var globalDB
 const store = {
   ALLOWLIST_URL: '/ext-libs/disconnect-entitylist.json',
   DB_IMPORT: '/ext-libs/lightbeamData.json',
@@ -6,6 +7,7 @@ const store = {
   async init() {
     if (!this.db) {
       this.makeNewDatabase();
+      console.log("importing database")
       await this.importDatabase()
     }
     browser.runtime.onMessage.addListener((m) => {
@@ -49,7 +51,9 @@ const store = {
     let dbdump;
     dbdump = await fetch(this.DB_IMPORT);
     dbdump = await dbdump.json();
-    console.log(dbdump)
+    globalDB = this.db
+    console.log({ dbump: dbdump })
+    console.log({ dbdump })
     for (const site in dbdump) {
       console.log({ site })
       let siteInfo = dbdump[site]

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -57,14 +57,17 @@ const store = {
       let res = await this._write(siteInfo)
       counter++
       if (counter % 100 == 0) {
+        console.log(siteInfo)
         console.log(`${counter} out of ${total} sites imported`)
       }
 
     }
     console.log("imported all the sites - woop woop")
     const importedSites = await this.getAll()
-    console.log(importedSites)
-    return importedSites
+    const importedAllSites = await this.getAllForImport()
+    console.log({ importedSites })
+    console.log({ importedAllSites })
+    return importedAllSites
   },
 
   // get Disconnect Entity List from shavar-prod-lists submodule
@@ -170,6 +173,7 @@ const store = {
 
     const publicMethods = [
       'getAll',
+      'getAllForImport',
       'reset',
       'getFirstRequestTime',
       'getNumFirstParties',
@@ -226,7 +230,8 @@ const store = {
       favicon: website.faviconUrl || '',
       firstPartyHostnames: website.firstPartyHostnames || false,
       firstParty: !!website.firstParty,
-      thirdParties: [],
+      isVisible: website.isVisible,
+      thirdParties: website.thirdParties || [],
       //  Eve is of course messing around with the below variable!!
       greenCheck: website.greenCheck
     };
@@ -240,6 +245,15 @@ const store = {
     const websites = await this.db.websites.filter((website) => {
       return website.isVisible || website.firstParty;
     }).toArray();
+    const output = {};
+    for (const website of websites) {
+      output[website.hostname] = this.outputWebsite(website.hostname, website);
+    }
+    return output;
+  },
+
+  async getAllForImport() {
+    const websites = await this.db.websites.toArray();
     const output = {};
     for (const website of websites) {
       output[website.hostname] = this.outputWebsite(website.hostname, website);

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -47,15 +47,24 @@ const store = {
   },
 
   async importDatabase(websites) {
+    console.log({ websites })
+    let counter = 0
+    const total = Object.entries(websites).length
+
     for (const site in websites) {
-      console.log({ site })
-      for (const site in websites) {
-        let siteInfo = websites[site]
-        console.log({ siteInfo })
-        let res = await this._write(siteInfo)
-        console.log({ res })
+      let siteInfo = websites[site]
+      // console.log({ siteInfo })
+      let res = await this._write(siteInfo)
+      counter++
+      if (counter % 100 == 0) {
+        console.log(`${counter} out of ${total} sites imported`)
       }
+
     }
+    console.log("imported all the sites - woop woop")
+    const importedSites = await this.getAll()
+    console.log(importedSites)
+    return importedSites
   },
 
   // get Disconnect Entity List from shavar-prod-lists submodule
@@ -178,21 +187,27 @@ const store = {
     }
   },
 
-  async importSiteData(url) {
+  async importSiteData(websites) {
+    console.log(`received call to import websites`)
+
+    console.log(`resetting db`)
+    const clearedDB = await this.reset()
     // check if the url is there
-    // console.log(`Received url to fetch: ${url}`)
+    // console.log(`Received url to fetch: ${ url }`)
     try {
       // fetch the url
-      const fetchedData = await fetch(url)
-      console.log({ fetchedData })
-      // try parsing it
-      const parsedSites = fetchedData.json()
-      console.log({ parsedSites })
+      // const fetchedData = await fetch(url)
+      // console.log({ fetchedData })
+      // // try parsing it
+      // const parsedSites = fetchedData.json()
+      // console.log({ parsedSites })
 
       // pass the datastructure to the store to import it
-      this.importDatabase(parsedSites)
+      console.log(`importing websites into db`, websites)
+      const importResult = await this.importDatabase(websites)
+      console.log({ importResult })
     } catch (error) {
-      console.log(error)
+      console.log({ error })
     }
 
   },


### PR DESCRIPTION
This PR, designed to address [issue 19][issue 19], and the related performance problems does a few things: 

[issue 19]: https://github.com/eveahe/greenbeam/issues/19

- adds the ability to import previously collected lightbeam datasets, with a new 'import' button
- adds an explicit limit for showing sites, to only show the most recent 100 first party sites, which can be changed
- adds a function, to allow us to export _all_ the sites stored in indexed DB

Combined, the export and import functions allow us to work with realistic datasets to test out new features and UI, without manually needing to click around a set of sites to see how datasets would work.

To decouple adding the performance improvements from the UI changes, I've commented out the import buttons and functions. Uncomment these lines, and make the download data button call `getAllForImport` to export the full dataset instead of the current one